### PR TITLE
Added Haymaker limb targeting

### DIFF
--- a/configs.js
+++ b/configs.js
@@ -106,6 +106,13 @@ nb.configs = {
 		"desc":"The target must have this number of affs on it or more in order to use Haymaker. Default: 3.",
 		"validateMsg":"haymaker_aff_threshold must be a number.",
 		"validate":function(v){return nb.isNumber(v);}
+	},
+	"haymaker_limb" : {
+		"val":"torso",
+		"category":"Scoundrel",
+		"desc":"If NB is using haymaker, it will target this limb. Default: torso",
+		"validateMsg":"haymaker_limb must be a string.",
+		"validate":function(v){return nb.isString(v);},
 	}
 }
 

--- a/scoundrel.js
+++ b/scoundrel.js
@@ -6,7 +6,7 @@ nb.offense.Scoundrel = function(){
 	//this is simplistic logic for haymaker for now, we can improve it later
 	var haymaker = nb.haveSkill("guile","haymaker") && nb.configs.use_haymaker.val && nb.tarAffs >= nb.configs.haymaker_aff_threshold.val
 	if (haymaker) {
-		return "guile haymaker "+nb.tar;
+		return "guile haymaker "+nb.tar+nb.configs.haymaker_limb.val;
 	}
 	if (nb.bullets === 0 || eject) {
 		if (fling) {

--- a/scoundrel.js
+++ b/scoundrel.js
@@ -6,7 +6,7 @@ nb.offense.Scoundrel = function(){
 	//this is simplistic logic for haymaker for now, we can improve it later
 	var haymaker = nb.haveSkill("guile","haymaker") && nb.configs.use_haymaker.val && nb.tarAffs >= nb.configs.haymaker_aff_threshold.val
 	if (haymaker) {
-		return "guile haymaker "+nb.tar+nb.configs.haymaker_limb.val;
+		return "guile haymaker "+nb.tar+" "+nb.configs.haymaker_limb.val;
 	}
 	if (nb.bullets === 0 || eject) {
 		if (fling) {


### PR DESCRIPTION
Changed config.js and scoundrel.js to enable haymaker_limb argument to config. This enables young scoundrels to bash with haymaker (head) once sensory ammo tips are available, but not internal ammo tips (350+ lessons later). Tested it on my fork and it seemed to work fine.