### PR TITLE
fix interrupt capturing wrong target

### DIFF
--- a/trigger.js
+++ b/trigger.js
@@ -8,7 +8,7 @@ nb.trigger = function(c) {
 		nb.onKill();
 	}
 	else if (nb.isInterruptLine(c)) {
-		nb.interrupt = true;
+		// nb.interrupt = true; // moving to line 49
 		nb.send("ih");
 	} else if (c.includes("You have learned the following abilities in this session")) {
 		display_notice("We notice you are gaining new skills. When you are finished learning, NBRELOAD so that Nexus Basher uses the best abilities", "green");
@@ -47,6 +47,7 @@ nb.trigger = function(c) {
 	}else if ((xyz = nb.interruptRegex.exec(c)) !== null) {
 		nb.debug("Interrupting mob "+JSON.stringify(xyz));
 		nb.chanTar = xyz[1];
+		nb.interrupt = true; // moved from line 11
 		nb.hider();
 	} else if (c.includes("Items here:")) {
                 nb.hideIH = true;

--- a/trigger.js
+++ b/trigger.js
@@ -8,7 +8,6 @@ nb.trigger = function(c) {
 		nb.onKill();
 	}
 	else if (nb.isInterruptLine(c)) {
-		// nb.interrupt = true; // moving to line 49
 		nb.send("ih");
 	} else if (c.includes("You have learned the following abilities in this session")) {
 		display_notice("We notice you are gaining new skills. When you are finished learning, NBRELOAD so that Nexus Basher uses the best abilities", "green");


### PR DESCRIPTION
Just moves line 11 to line 49 in triggers.js
This will only flag main.js to interrupt once the IH line has printed, parsed, and captured a target that is channeling. Plays nice with Neural Blinder.