### PR TITLE
Prioritize aggro mobs

### DIFF
--- a/mobs.js
+++ b/mobs.js
@@ -1,16 +1,58 @@
 //Add mobs here. Aggressive mobs go earlier in the list for an area.
 var mobs = [
-	//====================
-	// Aggressive mobs
-	//====================
-
-
-
-
+//====================
+// Aggressive mobs
+//====================
 
 	//====================
-	// Passive mobs
+	// 20-40
 	//====================
+	//Golpur
+	"an immense Rapasu worm","an enormous drakkafly",
+	//Kashitir
+    "a nightstalker","a juvenile nightstalker",
+	//Locorin
+	"a blacktooth coroxodon","a mossy shellback",
+    //Saksar
+	"a male Selassian cultist","a female Selassion cultist","an immense reptillian predator","a pack of small sharp-toothed reptiles",
+	"a scale-feathered scorpion bird","a sharp-toothed raptor",
+    //Siva
+	"a lean-ribbed skulf","a large hairy skulf","an immense alpha skulf",
+
+	//====================
+	// 40-50
+	//====================
+	//Pylos
+
+	//Greenwilds
+	"a luminous eel","a king tangutan",
+	//====================
+	// 50-75
+	//====================
+	//Anemoi
+	"a ravenous tigrid","a rabid cania","a carnivorous black eagle",
+	//Arrizuri
+	"a ferocious atzaparaki",
+	//Deisk
+	"a terrifying mekmavaur",
+	//Ixsei
+	"a crystal-clawed rock giant","a male Selassian mechanic","a female Selassian mechanic","a male Selassian Ophidian", 
+	"a female Selassian Ophidian","a male Selassian Viper","a female Selassian Viper","a male Selassian Venom","a female Selassian Venom", 
+	"a male Selassian Neonate","a female Selassian Neonate",
+	//Jelle
+	"a tough Bushraki drug runner","a dour Bushraki looter","a menacing Bushraki looter","an off-duty Bushraki looter",
+	"a virile heik-il vine",
+	//New Dikamazi
+	"the thrashing root of a cyborg leech orchid",
+	//Northern Usum
+	"an immense rapasu worm",
+	//Prugita
+	"a savage selakki",
+
+
+//====================
+// Passive mobs
+//====================
 
 	//====================
 	// 1-15
@@ -62,16 +104,16 @@ var mobs = [
     	"a small loam leech", "a saffron algerion", "a coral algerion", "a moss-hued algerion", "a large loam leech",
     	"an azure algerion", "an oversized loam leech", "a loam leech",
     	//Locorin
-    	"a blacktooth coroxodon","an enormous blacktooth coroxodon","a ruby-plumed eskama","a mossy shellback",
+    	"an enormous blacktooth coroxodon","a ruby-plumed eskama",
     	//Kashitir
-    	"a nightstalker","an indigo malaca","a juvenile nightstalker","a Grethen silkmoth","a collared malaca",
+    	"an indigo malaca","a Grethen silkmoth","a collared malaca",
     	//Golpur
-    	"an enormous drakkafly","an immense Rapasu worm","a flat balkrab","a giant black tarak beetle",
+    	"a flat balkrab","a giant black tarak beetle",
     	//Saksar
-    	"an immense reptillian predator","a male Selassian cultist","a female Selassion cultist","a sharp-toothed raptor","a coiling skilth snake",
-    	"a pack of small sharp-toothed reptiles","a scale-feathered scorpion bird","a blue-furred primate","a brutish loroi mercenary",
+    	"a coiling skilth snake",
+    	"a blue-furred primate","a brutish loroi mercenary",
     	//Siva
-     	"a needle-mouthed eel","an immense alpha skulf","a large hairy skulf","a lean-ribbed skulf","a spot-scaled tridactyl","a venomous tridactyl",
+     	"a needle-mouthed eel","a spot-scaled tridactyl","a venomous tridactyl",
 
 	//====================
 	// 40-50
@@ -82,7 +124,7 @@ var mobs = [
     	//Delta Deck
     	"a Fatar salvager","an armored salvage bot","a Bushraki mercenary","a Fatar guardian","an Elgan salvager","a Decheeran salvager","a Nusriza salvager",
     	//Greenwilds
-    	"a luminous eel","a king tangutan","a hulking arboreal lizard","a great white eagle","a giant guerilla beetle","a female tangutan",
+    	"a hulking arboreal lizard","a great white eagle","a giant guerilla beetle","a female tangutan",
     	//Tosmar
     	"a vicious haerbist","a tundra snake",
 
@@ -90,31 +132,26 @@ var mobs = [
 	// 50-75
 	//====================
 	//Anemoi
-	"a rabid cania","a ravenous tigrid","a carnivorous black eagle","a sly cania","a caliginous eagle","a brown-scaled tigrid",
+	"a sly cania","a caliginous eagle","a brown-scaled tigrid",
 	//Arrizuri
-	"a ferocious atzaparaki","a sluggish atzaparaki","a lumbering lasama",
+	"a sluggish atzaparaki","a lumbering lasama",
 	//Thait
 	"a ferociously toothed moss lizard","a needle-clawed moss lizard","a horned lapine","a three-eyed rosewing",
 	//New Dikamazi
-	"a rampaging construction mech","a dilapidated construction mech","the thrashing root of a cyborg leech orchid","a cyborg leech orchid",
+	"a rampaging construction mech","a dilapidated construction mech","a cyborg leech orchid",
 	//Jelle
-	"a thrashing heik-il vine","a monstrously huge heik-il vine","a dour Bushraki looter","a menacing Bushraki looter",
-	"a heavily armed male Bushraki guard","a heavily armed female Bushraki guard","an off-duty Bushraki looter","a tough Bushraki drug runner",
-	"a virile heik-il vine",
+	"a thrashing heik-il vine","a monstrously huge heik-il vine",
+	"a heavily armed male Bushraki guard","a heavily armed female Bushraki guard",
 	//Ixsei
-	"a crystal-clawed rock giant","a salt-crusted quartz creeper","a male Selassian mechanic","a female Selassian mechanic","a male Selassian Ophidian", 
-	"a female Selassian Ophidian","a male Selassian Viper","a female Selassian Viper","a male Selassian Venom","a female Selassian Venom", 
-	"a male Selassian Neonate","a female Selassian Neonate",
+	"a salt-crusted quartz creeper",
 	//Northern Usum
-	'a blacktooth coroxodon',"a giant tosmarian condor","an immense rapasu worm","an overfed skulf",
+	'a blacktooth coroxodon',"a giant tosmarian condor","an overfed skulf",
 	"a foraging zhubeast","an alert giant springer","a lurking blacktooth coroxodon","a large hairy skulf",
 	"a roosting tosmarian condor","a two-headed zhubeast","a juvenile rapasu worm","a coiling skilth snake",
 	"a giant springer","an immense reptilian predator",
 	//Prugita
-	"a savage selakki","a somnolent selakki","a stationary sentry bot",
+	"a somnolent selakki","a stationary sentry bot",
 	"a well-armed security bot","a Nabian guard",
-	//Deisk
-	"a terrifying mekmavaur",
 	//td
 	"a tentacle-limbed shapeshifter", "an eyeless maw",
 	//FeTek

--- a/mobs.js
+++ b/mobs.js
@@ -15,7 +15,7 @@ var mobs = [
 	// 20-40
 	//====================
 	//Golpur
-	"an immense Rapasu worm","an enormous drakkafly",
+	"an immense Rapasu worm","an enormous drakkafly","a giant black tarak beetle",
 	//Kashitir
     "a nightstalker","a juvenile nightstalker",
 	//Locorin
@@ -47,6 +47,10 @@ var mobs = [
 	"a ferocious atzaparaki",
 	//Deisk
 	"a terrifying mekmavaur",
+	//FeTek
+	"an out-of-control FeTek assembly drone",
+	//HugTech
+	"a malfunctioning remote manipulator",
 	//Ixsei
 	"a crystal-clawed rock giant","a male Selassian mechanic","a female Selassian mechanic","a male Selassian Ophidian", 
 	"a female Selassian Ophidian","a male Selassian Viper","a female Selassian Viper","a male Selassian Venom","a female Selassian Venom", 
@@ -55,9 +59,9 @@ var mobs = [
 	"a tough Bushraki drug runner","a dour Bushraki looter","a menacing Bushraki looter","an off-duty Bushraki looter",
 	"a virile heik-il vine",
 	//New Dikamazi
-	"the thrashing root of a cyborg leech orchid",
+	"the thrashing root of a cyborg leech orchid","a cyborg leech orchid","a rampaging construction mech",
 	//Northern Usum
-	"an immense rapasu worm",
+	"an immense rapasu worm","an overfed skulf","a lurking blacktooth coroxodon",
 	//Prugita
 	"a savage selakki",
 	//Thait
@@ -67,14 +71,38 @@ var mobs = [
 //====================
 // Wilderness exclusive aggros
 //====================
+	//Anemoi
+	"a diamond-backed scorptail",
 	//Arrizuri
-	"a fleshy-spined echidna",
+	"a fleshy-spined echidna","a stalk-eyed mayaki",
+	//Fogbound Marshes
+	"a bone-crested sohemuu","a spine-carapaced hari",
 	//Folly Fault Path
 	"a speckle-scaled sophilian",
 	//Golpur
 	"a broad-horned stripeback",
+	//Ixsei
+	"a crystal-headed tolma","a silver-scaled spinehusk",
+	//Jelle
+	"a tangle-bodied tentacla",
+	//Locorin
+	"an eight-eyed hagda",
+	//Oranc
+	"a bioluminescent irktin","a tough-skinned nesihorn",
+	//Prugita
+	"a stinger-footed hiver","a scoop-tusked gliven",
+	//Saksar
+	"a spot-pelted kumta","a ruby-pincered skitter",
 	//Servius Fault
 	"a green-spotted zemani",
+	//Suiko
+	"a long-legged trisurde","a twin-headed henizu","a metallic-furred fuber",
+	//Thait
+	"a purple-spotted fadeti",
+	//Tosmar
+	"a fleshy-crested denghoof","a spike-headed kusowo",
+	//Tranquility Deepness
+	"an eyeless maw",
 
 
 //====================
@@ -84,76 +112,77 @@ var mobs = [
 	//====================
 	// 1-15
 	//====================
-	//Southern Usum Usutti
-	"a yellow-feathered spiderax","a spotted mouse","a sleek shadow fox",
-	"a submerged tentacle","a medium-sized tentacle","a red-backed water bug",
+	//Dregs
+	"a miniature mauve rodent","a hairless vermilion rodent","a vicious vermilion rodent","a ravenous red rodent",
 	//Marle
 	"a Kronish Cross rockhopper","a large Kronish Cross rockhopper","a jumbo Kronish Cross rockhopper",
 	"a miniature Kronish Cross rockhopper","a stunted Kronish Cross rockhopper",
 	//Mirror Lake
 	"a water skipper","a sparkling eel","a small arboreal lizard",
-	//Dregs
-	"a miniature mauve rodent","a hairless vermilion rodent","a vicious vermilion rodent","a ravenous red rodent",
+	//Southern Usum Usutti
+	"a yellow-feathered spiderax","a spotted mouse","a sleek shadow fox",
+	"a submerged tentacle","a medium-sized tentacle","a red-backed water bug",
 
 	//====================
 	// 10-20
 	//====================
+	//Bodean
+	"an axropod",
+	//Coriolis
+	"a malfunctioning windmill drone","a venomous copper flitwing",
 	//Oldtown/Lower reaches/Undercity
 	"a glitch-riddled security robot", "an aggressively malfunctioning drone", "a skull-featured female Bushraki gang member",
 	"a skull-featured male Bushraki gang member", "a vibro-blade wielding Bushraki", "a savage dark-cloaked Bushraki",
-	//Coriolis
-	"a malfunctioning windmill drone","a venomous copper flitwing",
-	// Zephyr
-	"a buzzing lake darter",
 	//Scrapston
 	"a grime-slick eel","a poisonous eel",
-	//Whittler's hollow
-	"a fat terraworm","a meaty terraworm","an iridescent opal beetle", "a horrifically mutated rodent",
 	//Tabby
 	"a Ry'nari mutant wearing looted soldier fatigues","a grotesquely mutated bird", "a bile-skinned Amaian mutant", "a green-glowing Decheeran mutant", 
 	"a scab-scaled Ry'nari mutant","a grotesque Nusriza mutant", "a mutant encased in ancient power armor", "a warty Ry'nari mutant", 
 	"a tatter-finned Amaian mutant","a twisted Decheeran mutant","a spine-skinned Nusriza mutant",
-	//Bodean
-	"an axropod",
+	//Whittler's hollow
+	"a fat terraworm","a meaty terraworm","an iridescent opal beetle", "a horrifically mutated rodent",
+	//Zephyr
+	"a buzzing lake darter",
+
 
 	//====================
 	// 20-40
 	//====================
-	//Praviskar
-	"a merciless Bushraki occupier","an avaricious Bushraki slaver","a lightly armed Bushraki guardswoman","a lightly armed Bushraki guardsman",
-	"a heavily armed female Bushraki guard","a heavily armed male Bushraki guard",
-	//Oranc
-	"a stealthy poison-tooth","a green-scaled varrana","a great strider","a wind snake","a Krona poacher","a blue-crested ratika",
+	//Golpur
+	"a flat balkrab",
+	//Goribar
+	"a small loam leech", "a saffron algerion", "a coral algerion", "a moss-hued algerion", "a large loam leech",
+	"an azure algerion", "an oversized loam leech", "a loam leech",
+	//Kashitir
+	"an indigo malaca","a Grethen silkmoth","a collared malaca",
+	//Locorin
+	"a ruby-plumed eskama",
 	//Lowtown
 	"a juvenile heik-il vine",
 	"a thrashing heik-il vine","a sickly heik-il vine",
-    	//Goribar
-    	"a small loam leech", "a saffron algerion", "a coral algerion", "a moss-hued algerion", "a large loam leech",
-    	"an azure algerion", "an oversized loam leech", "a loam leech",
-    	//Locorin
-    	"a ruby-plumed eskama",
-    	//Kashitir
-    	"an indigo malaca","a Grethen silkmoth","a collared malaca",
-    	//Golpur
-    	"a flat balkrab","a giant black tarak beetle",
-    	//Saksar
-    	"a coiling skilth snake",
-    	"a blue-furred primate","a brutish loroi mercenary",
-    	//Siva
-     	"a spot-scaled tridactyl","a venomous tridactyl",
+	//Oranc
+	"a stealthy poison-tooth","a green-scaled varrana","a great strider","a wind snake","a Krona poacher","a blue-crested ratika",
+	//Praviskar
+	"a merciless Bushraki occupier","an avaricious Bushraki slaver","a lightly armed Bushraki guardswoman","a lightly armed Bushraki guardsman",
+	"a heavily armed female Bushraki guard","a heavily armed male Bushraki guard",
+	//Saksar
+	"a coiling skilth snake",
+	"a blue-furred primate","a brutish loroi mercenary",
+	//Siva
+	"a spot-scaled tridactyl","a venomous tridactyl",
 
 	//====================
 	// 40-50
 	//====================
+	//Delta Deck
+	"a Fatar salvager","an armored salvage bot","a Bushraki mercenary","a Fatar guardian","an Elgan salvager","a Decheeran salvager","a Nusriza salvager",
+	//Greenwilds
+	"a hulking arboreal lizard","a great white eagle","a giant guerilla beetle","a female tangutan",
 	//Pylos
-    	"a slow-moving hunk of living coral", "an algae-covered calciburr",
-    	"a poison-spitting treefrog","a delicately bulbous blinkfish",
-    	//Delta Deck
-    	"a Fatar salvager","an armored salvage bot","a Bushraki mercenary","a Fatar guardian","an Elgan salvager","a Decheeran salvager","a Nusriza salvager",
-    	//Greenwilds
-    	"a hulking arboreal lizard","a great white eagle","a giant guerilla beetle","a female tangutan",
-    	//Tosmar
-    	"a tundra snake",
+	"a slow-moving hunk of living coral", "an algae-covered calciburr",
+	"a poison-spitting treefrog","a delicately bulbous blinkfish",
+	//Tosmar
+	"a tundra snake",
 
 	//====================
 	// 50-75
@@ -162,29 +191,8 @@ var mobs = [
 	"a sly cania","a caliginous eagle","a brown-scaled tigrid",
 	//Arrizuri
 	"a sluggish atzaparaki","a lumbering lasama",
-	//Thait
-	"a needle-clawed moss lizard","a horned lapine","a three-eyed rosewing",
-	//New Dikamazi
-	"a rampaging construction mech","a dilapidated construction mech","a cyborg leech orchid",
-	//Jelle
-	"a thrashing heik-il vine","a monstrously huge heik-il vine",
-	"a heavily armed male Bushraki guard","a heavily armed female Bushraki guard",
-	//Ixsei
-	"a salt-crusted quartz creeper",
-	//Northern Usum
-	'a blacktooth coroxodon',"a giant tosmarian condor","an overfed skulf",
-	"a foraging zhubeast","an alert giant springer","a lurking blacktooth coroxodon","a large hairy skulf",
-	"a roosting tosmarian condor","a two-headed zhubeast","a juvenile rapasu worm","a coiling skilth snake",
-	"a giant springer","an immense reptilian predator",
-	//Prugita
-	"a somnolent selakki","a stationary sentry bot",
-	"a well-armed security bot","a Nabian guard",
-	//td
-	"a tentacle-limbed shapeshifter", "an eyeless maw",
-	//FeTek
-	"an out-of-control FeTek assembly drone",
 	//HugTech
-	"a malfunctioning remote manipulator","a malfunctioning remote manipulator","a fuzzy cerise tentacle plushie with half a face",
+	"a fuzzy cerise tentacle plushie with half a face",
 	"a bright bronze ice crab plushie with half a face","a plump bronze haerbist plushie with half a face","a tattered copper skulf plushie with half a face",
 	"a charming rose eckin plushie with a dangling broken arm","a plain silver spiderax plushie with a glitching voicebox","a matted pink heik-il plushie with half a face",
 	"a fuzzy orange giant-springer plushie with a dangling broken arm","a plump white coroxodon plushie with half a face",
@@ -194,33 +202,39 @@ var mobs = [
 	"a furry slate shellback plushie with half a face","a plump silver quartz-creeper plushie with a moth-eaten hole in its torso",
 	"a button-eyed indigo terraworm plushie with half a face","a misshapen redberry atzaparaki plushie with one eye hanging out",
 	"a feathery emerald zhubeast plushie with half a face","a matted lilac merova plushie with a glitching voicebox","a beady-eyed albino knockout rat",
-	
-	//Wilderness
-	// Oranc
-	"a tough-skinned nesihorn","a bioluminescent irktin",
-	//Fogbound Marshes
-	"a spine-carapaced hari","a bone-crested sohemuu","a dark-furred and floating fleel",
-	//Prugita
-	"a stinger-footed hiver","a four-eared remes rat","a scoop-tusked gliven",
-	//Jelle
-	"a tangle-bodied tentacla",
-	//Locorin
-	"an eight-eyed hagda", "a nightstalker", "a feathered draken lizard",
-	//Thait
-	"a purple-spotted fadeti","a star-nosed burrower",
-	//Saksar
-	"a spot-pelted kumta","a ruby-pincered skitter",
-	//Anemoi
-	"a diamond-backed scorptail","a spiral-horned kegri", 
-	//Arrizuri
-	"a stalk-eyed mayaki",
 	//Ixsei
-	"a crystal-headed tolma","a silver-scaled spinehusk",
-	//Suiko
-	"a long-legged trisurde","a twin-headed henizu","a metallic-furred fuber",
-	//Tosmar
-	"a fleshy-crested denghoof","a spike-headed kusowo",
+	"a salt-crusted quartz creeper",
+	//Jelle
+	"a thrashing heik-il vine","a monstrously huge heik-il vine",
+	"a heavily armed male Bushraki guard","a heavily armed female Bushraki guard",
+	//New Dikamazi
+	"a dilapidated construction mech",
+	//Northern Usum
+	'a blacktooth coroxodon',"a giant tosmarian condor",
+	"a foraging zhubeast","an alert giant springer","a large hairy skulf",
+	"a roosting tosmarian condor","a two-headed zhubeast","a juvenile rapasu worm","a coiling skilth snake",
+	"a giant springer","an immense reptilian predator",
+	//Prugita
+	"a somnolent selakki","a stationary sentry bot",
+	"a well-armed security bot","a Nabian guard",
+	//Tranquility Deepness
+	"a tentacle-limbed shapeshifter",
+	//Thait
+	"a needle-clawed moss lizard","a horned lapine","a three-eyed rosewing",
 
+//====================
+// Wilderness passives
+//====================
+	//Anemoi
+	"a spiral-horned kegri", 
+	//Fogbound Marshes
+	"a dark-furred and floating fleel",
+	//Locorin
+	"a nightstalker", "a feathered draken lizard",
+	//Prugita
+	"a four-eared remes rat",
+	//Thait
+	"a star-nosed burrower",
 ];
 
 //names of mechanical targets go here. 

--- a/mobs.js
+++ b/mobs.js
@@ -148,6 +148,8 @@ var mobs = [
 	"a long-legged trisurde","a twin-headed henizu","a metallic-furred fuber",
 	//Tosmar
 	"a fleshy-crested denghoof","a spike-headed kusowo",
+	//Golpur
+	"a broad-horned stripeback",
 ];
 
 //names of mechanical targets go here. 

--- a/mobs.js
+++ b/mobs.js
@@ -1,6 +1,18 @@
 //Add mobs here. Aggressive mobs go earlier in the list for an area.
 var mobs = [
 	//====================
+	// Aggressive mobs
+	//====================
+
+
+
+
+
+	//====================
+	// Passive mobs
+	//====================
+
+	//====================
 	// 1-15
 	//====================
 	//Southern Usum Usutti

--- a/mobs.js
+++ b/mobs.js
@@ -3,6 +3,13 @@ var mobs = [
 //====================
 // Aggressive mobs
 //====================
+	//====================
+	// 10-20
+	//====================
+	//Coriolis
+	"a malfunctioning windmill drone",
+	//Scrapston
+	"a needle-mouthed eel",
 
 	//====================
 	// 20-40
@@ -12,20 +19,25 @@ var mobs = [
 	//Kashitir
     "a nightstalker","a juvenile nightstalker",
 	//Locorin
-	"a blacktooth coroxodon","a mossy shellback",
+	"a blacktooth coroxodon","a mossy shellback","an enormous blacktooth coroxodon",
+	//Lowtown
+	"a shifty looking Nath-el","a strung-out female Lowtowner","a strung-out male Lowtowner","an oversized heik-il vine",
     //Saksar
 	"a male Selassian cultist","a female Selassion cultist","an immense reptillian predator","a pack of small sharp-toothed reptiles",
 	"a scale-feathered scorpion bird","a sharp-toothed raptor",
     //Siva
-	"a lean-ribbed skulf","a large hairy skulf","an immense alpha skulf",
+	"a lean-ribbed skulf","a large hairy skulf","an immense alpha skulf","a needle-mouthed eel",
 
 	//====================
 	// 40-50
 	//====================
 	//Pylos
-
+	"a depthless puddle of black liquid","a tentacle-finned hookmaw",
 	//Greenwilds
 	"a luminous eel","a king tangutan",
+	//Tosmar
+	"a vicious haerbist",
+
 	//====================
 	// 50-75
 	//====================
@@ -48,6 +60,21 @@ var mobs = [
 	"an immense rapasu worm",
 	//Prugita
 	"a savage selakki",
+	//Thait
+	"a ferociously toothed moss lizard",
+
+
+//====================
+// Wilderness exclusive aggros
+//====================
+	//Arrizuri
+	"a fleshy-spined echidna",
+	//Folly Fault Path
+	"a speckle-scaled sophilian",
+	//Golpur
+	"a broad-horned stripeback",
+	//Servius Fault
+	"a green-spotted zemani",
 
 
 //====================
@@ -79,7 +106,7 @@ var mobs = [
 	// Zephyr
 	"a buzzing lake darter",
 	//Scrapston
-	"a grime-slick eel","a needle-mouthed eel","a poisonous eel",
+	"a grime-slick eel","a poisonous eel",
 	//Whittler's hollow
 	"a fat terraworm","a meaty terraworm","an iridescent opal beetle", "a horrifically mutated rodent",
 	//Tabby
@@ -98,13 +125,13 @@ var mobs = [
 	//Oranc
 	"a stealthy poison-tooth","a green-scaled varrana","a great strider","a wind snake","a Krona poacher","a blue-crested ratika",
 	//Lowtown
-	"a strung-out female Lowtowner","a strung-out male Lowtowner","an oversized heik-il vine","a shifty looking Nath-el","a juvenile heik-il vine",
+	"a juvenile heik-il vine",
 	"a thrashing heik-il vine","a sickly heik-il vine",
     	//Goribar
     	"a small loam leech", "a saffron algerion", "a coral algerion", "a moss-hued algerion", "a large loam leech",
     	"an azure algerion", "an oversized loam leech", "a loam leech",
     	//Locorin
-    	"an enormous blacktooth coroxodon","a ruby-plumed eskama",
+    	"a ruby-plumed eskama",
     	//Kashitir
     	"an indigo malaca","a Grethen silkmoth","a collared malaca",
     	//Golpur
@@ -113,20 +140,20 @@ var mobs = [
     	"a coiling skilth snake",
     	"a blue-furred primate","a brutish loroi mercenary",
     	//Siva
-     	"a needle-mouthed eel","a spot-scaled tridactyl","a venomous tridactyl",
+     	"a spot-scaled tridactyl","a venomous tridactyl",
 
 	//====================
 	// 40-50
 	//====================
 	//Pylos
-    	"a tentacle-finned hookmaw", "a slow-moving hunk of living coral", "an algae-covered calciburr",
-    	"a depthless puddle of black liquid", "a poison-spitting treefrog","a delicately bulbous blinkfish",
+    	"a slow-moving hunk of living coral", "an algae-covered calciburr",
+    	"a poison-spitting treefrog","a delicately bulbous blinkfish",
     	//Delta Deck
     	"a Fatar salvager","an armored salvage bot","a Bushraki mercenary","a Fatar guardian","an Elgan salvager","a Decheeran salvager","a Nusriza salvager",
     	//Greenwilds
     	"a hulking arboreal lizard","a great white eagle","a giant guerilla beetle","a female tangutan",
     	//Tosmar
-    	"a vicious haerbist","a tundra snake",
+    	"a tundra snake",
 
 	//====================
 	// 50-75
@@ -136,7 +163,7 @@ var mobs = [
 	//Arrizuri
 	"a sluggish atzaparaki","a lumbering lasama",
 	//Thait
-	"a ferociously toothed moss lizard","a needle-clawed moss lizard","a horned lapine","a three-eyed rosewing",
+	"a needle-clawed moss lizard","a horned lapine","a three-eyed rosewing",
 	//New Dikamazi
 	"a rampaging construction mech","a dilapidated construction mech","a cyborg leech orchid",
 	//Jelle
@@ -171,12 +198,8 @@ var mobs = [
 	//Wilderness
 	// Oranc
 	"a tough-skinned nesihorn","a bioluminescent irktin",
-	//Folly Fault Path
-	"a speckle-scaled sophilian",
 	//Fogbound Marshes
 	"a spine-carapaced hari","a bone-crested sohemuu","a dark-furred and floating fleel",
-	//Servius Fault
-	"a green-spotted zemani", "a green-spotted zemani",
 	//Prugita
 	"a stinger-footed hiver","a four-eared remes rat","a scoop-tusked gliven",
 	//Jelle
@@ -190,15 +213,14 @@ var mobs = [
 	//Anemoi
 	"a diamond-backed scorptail","a spiral-horned kegri", 
 	//Arrizuri
-	"a fleshy-spined echidna","a stalk-eyed mayaki",
+	"a stalk-eyed mayaki",
 	//Ixsei
 	"a crystal-headed tolma","a silver-scaled spinehusk",
 	//Suiko
 	"a long-legged trisurde","a twin-headed henizu","a metallic-furred fuber",
 	//Tosmar
 	"a fleshy-crested denghoof","a spike-headed kusowo",
-	//Golpur
-	"a broad-horned stripeback",
+
 ];
 
 //names of mechanical targets go here. 


### PR DESCRIPTION
Since the list is consulted in order of appearance, I've moved all known aggro mobs to appear before passives. If they happen to show up in the same room, the passive mob should not be prioritized anymore.